### PR TITLE
Fix bug when task was completing successfully even if db connection error occurred

### DIFF
--- a/src/main/java/com/blog/entities/task/Task.java
+++ b/src/main/java/com/blog/entities/task/Task.java
@@ -48,7 +48,7 @@ public class Task {
      * <p>
      * State is updated with every new step in task being executed.
      *
-     * @see Task.State
+     * @see State
      */
     @Enumerated(EnumType.STRING)
     private State state;

--- a/src/main/java/com/blog/manager/BackupLoadManager.java
+++ b/src/main/java/com/blog/manager/BackupLoadManager.java
@@ -331,7 +331,7 @@ public class BackupLoadManager {
                 }
             }
 
-            logger.info("Backup deleted. Backup info: {}. Exception occurred: {}", backupProperties, exceptions);
+            logger.info("Backup deleted. Backup info: {}. Exceptions occurred: {}", backupProperties, exceptions);
         } catch (InterruptedException ex) {
             // unfinished tasks automatically canceled here by executor service
             Thread.currentThread().interrupt();

--- a/src/main/java/com/blog/manager/TasksManager.java
+++ b/src/main/java/com/blog/manager/TasksManager.java
@@ -112,12 +112,12 @@ public class TasksManager {
             case APPLYING_DEPROCESSORS:
             case RESTORING:
             case DELETING: {
-                logger.info("Handling broken operation. Operation: {}. No extra actions required", state.toString());
+                logger.info("Handling broken operation. Operation: {}: No extra actions required. Task info: {}", state, task);
                 break;
             }
             case CREATING:
             case APPLYING_PROCESSORS: {
-                logger.info("Handling broken operation. Operation: {}. Delete backup properties...", state.toString());
+                logger.info("Handling broken operation. Operation: {}: Deleting backup properties... Task info: {}", state, task);
 
                 Integer backupPropertiesID = task.getBackupPropertiesId();
 
@@ -130,11 +130,11 @@ public class TasksManager {
                 break;
             }
             case UPLOADING: {
-                logger.info("Handling broken operation. Operation: {}. Deleting backup from storage...", state);
+                logger.info("Handling broken operation. Operation: {}: Deleting backup from storage... Task info: {}", state, task);
 
                 Integer backupPropertiesId = task.getBackupPropertiesId();
                 Optional<BackupProperties> optionalBackupProperties = backupPropertiesManager.findById(backupPropertiesId);
-                if (!optionalBackupProperties.isPresent()) {
+                if (optionalBackupProperties.isEmpty()) {
                     logger.error("Can't revert task: no related backup properties. Task info: {}", task);
                     return;
                 }
@@ -144,7 +144,7 @@ public class TasksManager {
                 break;
             }
             default: {
-                logger.error("Can't revert task: unknown state. Task info: {}", task);
+                logger.error("Can't revert task: invalid state. Task info: {}", task);
             }
         }
     }

--- a/src/main/java/com/blog/service/ErrorCallbackService.java
+++ b/src/main/java/com/blog/service/ErrorCallbackService.java
@@ -43,21 +43,21 @@ public class ErrorCallbackService {
      *
      * @param t      an exception
      * @param taskId task id
-     * @implNote we set error only if cancellation was successful. If it's not, then task already was interrupted by user or some other error.
+     * @implNote we set error only if cancellation was successful. If it's not, that means task was already interrupted by user or other error.
      */
     public void onError(@NotNull Throwable t, @NotNull Integer taskId) {
         logger.error("Exception caught. Task ID: {}", taskId, t);
 
         Optional<Future> optionalFuture = tasksStarterService.getFuture(taskId);
-        if (!optionalFuture.isPresent()) {
-            logger.error("Can't cancel the Future of task with ID {}: no such Future instance", taskId);
+        if (optionalFuture.isEmpty()) {
+            logger.error("Can't cancel a Future of the task with ID {}: no such Future instance", taskId);
         } else {
             boolean canceled = optionalFuture.get().cancel(true);
             if (!canceled) {
-                logger.error("Error canceling the Future of task with ID {}", taskId);
+                logger.error("Error canceling a Future of the task with ID {}", taskId);
             } else {
-                logger.info("Task canceled. Task ID: {}", taskId);
                 errorTasksManager.addErrorTask(taskId);
+                logger.info("Task canceled and error status set. Task ID: {}", taskId);
             }
         }
     }

--- a/src/main/java/com/blog/service/TasksStarterService.java
+++ b/src/main/java/com/blog/service/TasksStarterService.java
@@ -128,10 +128,8 @@ public class TasksStarterService {
                     logger.info("Uploading backup...");
 
                     backupLoadManager.uploadBackup(processedBackupStream, backupProperties, taskId);
-                    if (Thread.interrupted()) {
-                        throw new InterruptedException();
-                    }
 
+                    Thread.sleep(5000);
                     tasksManager.updateTaskState(taskId, Task.State.COMPLETED);
                     logger.info("Creating backup completed. Backup properties: {}", backupProperties);
                 }
@@ -142,7 +140,7 @@ public class TasksStarterService {
                 errorTasksManager.addErrorTask(taskId);
             } catch (InterruptedException ex) {
                 tasksManager.setInterrupted(taskId);
-                logger.error("Backup creating task was interrupted. Task ID: {}", taskId);
+                logger.error("Backup creation task was interrupted. Task ID: {}", taskId);
             } finally {
                 futures.remove(taskId);
             }


### PR DESCRIPTION
When checking a reason of the occurred error in backup creation method, PostgresDatabaseBackup was trying to detect closed stream. If it is, it was treated as not a error. But there are case when error occurred and stream was closed on resources releasing, but not by error or interruption, so the occurred error was ignored. 

**Fix:** replace checking of the stream programmatically with checking of process's exit code. Exit code 141 means write error and that's what we really need when detecting closed stream.